### PR TITLE
Avoid double-evaluation of 'register' macro argument

### DIFF
--- a/fullframe.el
+++ b/fullframe.el
@@ -56,16 +56,17 @@
   state in REGISTER and display a single frame. Advice COMMAND-OFF to
   restore the state stored in REGISTER. If KILL-ON-COFF is true,
   kill-buffer is called on command-off."
-  (let ((on-rule-name (gensym "fullscreen-rule-"))
-        (off-rule-name (gensym "restore-setup-rule-"))
-        (off-code (if kill-on-coff
-                      `(progn
-                         (kill-buffer)
-                         (jump-to-register ,register))
-                    `(jump-to-register ,register))))
-    `(progn
+  (let* ((on-rule-name (gensym "fullscreen-rule-"))
+         (off-rule-name (gensym "restore-setup-rule-"))
+         (register-name (gensym))
+         (off-code (if kill-on-coff
+                       `(progn
+                          (kill-buffer)
+                          (jump-to-register ,register-name))
+                     `(jump-to-register ,register-name))))
+    `(let ((,register-name ,register))
        (defadvice ,command-on (around ,on-rule-name activate)
-         (window-configuration-to-register ,register)
+         (window-configuration-to-register ,register-name)
          ad-do-it
          (delete-other-windows))
        (defadvice ,command-off (after ,off-rule-name activate)


### PR DESCRIPTION
The macro still isn't 100% safe, since certain symbols are evaluated more than once.

So given:

``` el
(defun some-register-name ()
  ... side effects here ...
  :ibuffer-fullscreen)

(fullframe ibuffer ibuffer-quit (some-register-name) nil)
```

the expansion is:

``` el
(progn
  (defadvice ibuffer
      (around fullscreen-rule-23514 activate)
    (window-configuration-to-register
     (some-register-name))
    ad-do-it
    (delete-other-windows))
  (defadvice ibuffer-quit
      (after restore-setup-rule-23515 activate)
    (jump-to-register
     (some-register-name))))
```

when clearly `some-register-name` should only be called once. This is a common macro-writing pitfall covered best (I think) in [Practical Common Lisp](http://gigamonkeys.com/book/macros-defining-your-own.html).

This commit illustrates how to avoid double evaluation in this case. :-)
