### PR TITLE
Make sure gensym is available

### DIFF
--- a/fullframe.el
+++ b/fullframe.el
@@ -40,6 +40,8 @@
 ;;
 ;;; Code:
 
+(eval-when-compile (require 'cl))
+
 ;; customization
 ;; - none
 
@@ -76,4 +78,9 @@
 ;; - none
 
 (provide 'fullframe)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
+
 ;;; fullframe.el ends here


### PR DESCRIPTION
Without this addition, people who haven't loaded the `cl` library will find this packages fails to install.

Additionally silence some additional compilation warnings that turn up as a result.

Fixes #3
