### PR TITLE
Ignore errors when restoring window configurations after command

### DIFF
--- a/fullframe.el
+++ b/fullframe.el
@@ -75,7 +75,9 @@ Advice execution of command-on to store the current window until
                        `(progn
                           (kill-buffer)
                           (jump-to-register ,register-name))
-                     `(jump-to-register ,register-name))))
+                     `(condition-case nil
+                          (jump-to-register ,register-name)
+                        (error (message "Failed to restore all windows."))))))
     `(progn
        (defvar ,allow-unwind-var ,any-buffer)
        (make-variable-buffer-local ',allow-unwind-var)


### PR DESCRIPTION
If a user runs ibuffer or magit full-frame, then commands such as
killing buffers can make it impossible for the window configuration to
be fully restored from the saved register.

This commit handles such errors and prints a warning.
