### PR TITLE
replace 'equal' with 'eq'. Fixes #13.

### DIFF
--- a/fullframe.el
+++ b/fullframe.el
@@ -112,7 +112,7 @@ IGNORED is there for backcompatibillitys sake -- ignore it."
           ad-do-it
           (let ((,window-config-post (current-window-configuration)))
             (delete-other-windows)
-            (unless (equal ,window-config-post (current-window-configuration))
+            (unless (eq ,window-config-post (current-window-configuration))
               (setq fullframe/previous-window-configuration ,window-config)))))
       (defadvice ,command-off (around fullframe activate)
         (let ((,window-config fullframe/previous-window-configuration)


### PR DESCRIPTION
I have the feeling this is probably not a real fix for #13, but may introduce back the behaviour described in #12 (it doesn't for my ad hoc tests!). @purcell would you be so kind to check eq vs. equal against your expectations?

I can't print window-configurations, so I don't know how to debug this case.
