### PR TITLE
Simpler solution to the multiple command-on call problem.

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,5 +1,8 @@
 * Generalized automatic execution in a single frame
 
+[[http://melpa.org/#/fullframe][file:http://melpa.org/packages/fullframe-badge.svg]]
+[[http://stable.melpa.org/#/fullframe][file:http://stable.melpa.org/packages/fullframe-badge.svg]]
+
 This is a library that package developers can use to provide user
 friendly single window per frame execution of buffer exposing
 commands, as well as to use in personal emacs configurations to attain

--- a/fullframe.el
+++ b/fullframe.el
@@ -51,7 +51,9 @@
 (make-variable-buffer-local 'fullframe/previous-window-configuration)
 
 (defvar fullframe/other-windows-deleted nil
-  "The window configuration to restore.")
+  "Don't overwrite `fullframe/previous-window-configuration' if
+  `command-on` is called more then once without intermediate
+  `command-off' calls.")
 (make-variable-buffer-local 'fullframe/other-windows-deleted)
 
 ;; internal functions

--- a/fullframe.el
+++ b/fullframe.el
@@ -112,7 +112,7 @@ IGNORED is there for backcompatibillitys sake -- ignore it."
           ad-do-it
           (let ((,window-config-post (current-window-configuration)))
             (delete-other-windows)
-            (unless (equal ,window-config-post (current-window-configuration))
+            (unless (eq ,window-config-post (current-window-configuration))
               (setq fullframe/previous-window-configuration ,window-config)))))
       (defadvice ,command-off (around fullframe activate)
         (let ((,window-config fullframe/previous-window-configuration)


### PR DESCRIPTION
Use `compare-window-configurations` instead of `equal`.

Simply remember the fullframe state in a buffer local variable only
set and unset in the target buffer.  If it is already set, we don't store
the current window configuration.

This indeed fixes #13 for me with the usage of fullframe in
`repl-toggl`.  The magit scenario as describe by @purcell in #15 is
reproducible even when no fullframe.el advice to magit is present.
