### PR TITLE
Declare package dependency on cl-lib

### DIFF
--- a/fullframe.el
+++ b/fullframe.el
@@ -6,6 +6,7 @@
 ;; Maintainer: Tom Regner <tom@goochesa.de>
 ;; Version: 0.1.0
 ;; Keywords: fullscreen
+;; Package-Requires: ((cl-lib "0.5"))
 
 ;;  This file is NOT part of GNU Emacs
 


### PR DESCRIPTION
This missing dep has been seen to cause issues on Emacs 23: https://github.com/purcell/emacs.d/issues/188
