### PR TITLE
Fixes for issues with current version

### DIFF
--- a/fullframe.el
+++ b/fullframe.el
@@ -138,8 +138,8 @@ the window it generated is the only one in in the frame.
           (off-code `(progn
                        (fullframe/maybe-restore-configuration ,window-config)
                        ,@(when kill-on-coff (list `(kill-buffer ,buf))))))
-      `(if (version< emacs-version "24.4")
-           (progn
+      (if (version< emacs-version "24.4")
+          `(progn
              (defadvice ,command-on (around fullframe activate)
                (let ((,window-config (current-window-configuration)))
                  ad-do-it
@@ -150,7 +150,7 @@ the window it generated is the only one in in the frame.
                  (prog1
                      ad-do-it
                    ,off-code))))
-         (progn
+        `(progn
            (advice-add #',command-on :around
                        #'(lambda (orig-fun &rest args)
                            (let ((,window-config (current-window-configuration)))


### PR DESCRIPTION
This PR addresses the following problems:

- Code for < 24.4 was broken, due to reference in advice to
  after-command-on-func
- When after-command-on-func was nil (the common case), the "Not a
  function" message was printed every time command-on is triggered

The commit also unifies the code in the old/new style advice
declarations so they will always match each other. It also avoids
spurious "nil" forms in the output code.