### PR TITLE
Require cl-lib, not cl

### DIFF
--- a/fullframe.el
+++ b/fullframe.el
@@ -42,8 +42,7 @@
 ;;; Code:
 
 
-(eval-when-compile
-  (require 'cl))
+(require 'cl-lib)
 
 ;; customization
 ;; - none


### PR DESCRIPTION
This omission can cause fullframe to fail if it is loaded before some other package has initially loaded cl-lib.